### PR TITLE
fix: 사이드 바와 태그 페이지에서 일정 클릭 시 색상 안뜨는 문제 해결

### DIFF
--- a/src/components/TagItem.jsx
+++ b/src/components/TagItem.jsx
@@ -129,6 +129,7 @@ const TagItem = ({ eventsList }) => {
       date: event.date,
       content: event.content || "",
       tagName: event.tagName || "",
+      tagColor: event.tagColor || "", // 태그 색상 추가
       is_completed: event.is_completed,
       deadline: event.deadline || null,
     };

--- a/src/components/TodoItem.jsx
+++ b/src/components/TodoItem.jsx
@@ -29,6 +29,7 @@ function TodoItem({ task, checked }) {
       date: task.date,
       content: task.content,
       tagName: task.tagName,
+      tagColor: task.tagColor || "", // 태그 색상 추가
       is_completed: task.is_completed,
       deadline: task.deadline,
     });


### PR DESCRIPTION
사이드 바와 태그 페이지에서 일정 클릭 시 색상 안뜨는 문제 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 태그 클릭 시, 태그 색상 정보가 함께 전달되어 표시됩니다.
  * 할 일 항목 클릭 시, 태그 색상 정보가 함께 전달되어 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->