### PR TITLE
fix: 태그atom 임시 수정

### DIFF
--- a/src/api/ECampusScheduleFetcher.jsx
+++ b/src/api/ECampusScheduleFetcher.jsx
@@ -10,12 +10,15 @@ const fetchECampusSchedule = async () => {
 
     const token = loginResult.access;
 
-    const response = await axios.get("http://schedulo.store/users/crawling/", {
-      withCredentials: true,
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
+    const response = await axios.get(
+      "http://schedulo.store/users/crawling/",
+      {
+        withCredentials: true,
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
 
     const { courses } = response.data;
     console.log("크롤링 데이터", courses);

--- a/src/api/GetCookie.jsx
+++ b/src/api/GetCookie.jsx
@@ -3,7 +3,7 @@ import axios from "axios";
 const GetCookie = async () => {
   try {
     const response = await axios.post(
-      "http://13.124.140.60/users/login/",
+      "https://schedulo.store/users/login/",
       {
         email: "hyjoo0909@naver.com",
         password: "0909",

--- a/src/api/addScheduleApi.js
+++ b/src/api/addScheduleApi.js
@@ -9,7 +9,7 @@ const addSchedules = async (data) => {
 
   try {
     const response = await axios.post(
-      `http://13.124.140.60/schedules/`,
+      `https://schedulo.store/schedules/`,
       {
         title: data.title,
         content: data.content,

--- a/src/api/addTagApi.js
+++ b/src/api/addTagApi.js
@@ -7,7 +7,7 @@ const addTag = async (tag) => {
 
   try {
     const response = await axios.post(
-      `http://13.124.140.60/schedules/tags/`,
+      `https://schedulo.store/schedules/tags/`,
       {
         name: tag,
       },

--- a/src/api/addTagsApi.js
+++ b/src/api/addTagsApi.js
@@ -7,7 +7,7 @@ const addTags = async (name) => {
 
   try {
     const response = await axios.post(
-      `http://13.124.140.60/schedules/tags/`,
+      `https://schedulo.store/schedules/tags/`,
       {
         name: name,
       },

--- a/src/api/checkScheduleApi.js
+++ b/src/api/checkScheduleApi.js
@@ -8,7 +8,7 @@ const fetchSchedules = async (firstDate, lastDate) => {
 
   try {
     const response = await axios.get(
-      `http://13.124.140.60/schedules/list/`,
+      `https://schedulo.store/schedules/list/`,
       {
         params: {
           first: firstDate,

--- a/src/api/deleteScheduleApi.js
+++ b/src/api/deleteScheduleApi.js
@@ -9,7 +9,7 @@ const deleteSchedules = async (id) => {
   console.log("id", id);
   try {
     const response = await axios.delete(
-      `http://13.124.140.60/schedules/${id}/`,
+      `https://schedulo.store/schedules/${id}/`,
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/src/api/deleteTagApi.js
+++ b/src/api/deleteTagApi.js
@@ -9,7 +9,7 @@ const deleteTag = async (tagId) => {
 
   try {
     const response = await axios.delete(
-      `http://13.124.140.60/schedules/tags/${tagId}/`,
+      `https://schedulo.store/schedules/tags/${tagId}/`,
       {
         headers: {
           "Content-Type": "application/json",

--- a/src/api/getTagsApi.js
+++ b/src/api/getTagsApi.js
@@ -7,7 +7,7 @@ const getTags = async () => {
 
   try {
     const response = await axios.get(
-      `http://13.124.140.60/schedules/tags/`,
+      `https://schedulo.store/schedules/tags/`,
       {
         headers: {
           "Content-Type": "application/json",

--- a/src/api/getTagsListApi.js
+++ b/src/api/getTagsListApi.js
@@ -8,7 +8,7 @@ const getTagList = async () => {
 
   try {
     const response = await axios.get(
-      `http://13.124.140.60/schedules/tags/`,
+      `https://schedulo.store/schedules/tags/`,
       {
         headers: {
           "Content-Type": "application/json",

--- a/src/api/getUserScoresApi.js
+++ b/src/api/getUserScoresApi.js
@@ -7,7 +7,7 @@ const getScores = async () => {
 
   try {
     const response = await axios.get(
-      `http://13.124.140.60/users/scores/`,
+      `https://schedulo.store/users/scores/`,
 
       {
         params: {

--- a/src/api/putTagApi.js
+++ b/src/api/putTagApi.js
@@ -9,7 +9,7 @@ const putTag = async (tag, tagId) => {
 
   try {
     const response = await axios.put(
-      `http://13.124.140.60/schedules/tags/${tagId}/`,
+      `https://schedulo.store/schedules/tags/${tagId}/`,
       {
         name: tag,
       },

--- a/src/api/updateScheduleApi.js
+++ b/src/api/updateScheduleApi.js
@@ -7,7 +7,7 @@ const updateSchedules = async (data) => {
 
   try {
     const response = await axios.put(
-      `http://13.124.140.60/schedules/${data.id}/`,
+      `https://schedulo.store/schedules/${data.id}/`,
       {
         title: data.title,
         content: data.content,

--- a/src/atoms/HomeAtoms.jsx
+++ b/src/atoms/HomeAtoms.jsx
@@ -75,7 +75,7 @@ const ScheduleCompleteOrNot = async ({ data }) => {
 
   try {
     const response = await fetch(
-      `http://13.124.140.60/schedules/${id}`,
+      `https://schedulo.store/schedules/${id}`,
       {
         method: "PUT",
         headers: {

--- a/src/components/TimeTableForm.jsx
+++ b/src/components/TimeTableForm.jsx
@@ -100,7 +100,7 @@ const TimeTableForm = () => {
     const fetchInitialSchedule = async () => {
       try {
         const response = await axios.get(
-          "http://13.124.140.60/schedules/timetables/",
+          "https://schedulo.store/schedules/timetables/",
           {
             headers: {
               Authorization: `Bearer ${token}`,

--- a/src/pages/Tag.jsx
+++ b/src/pages/Tag.jsx
@@ -11,6 +11,7 @@ import plusBtn from "../assets/tag/plusBtn.svg";
 //모달
 import ScheduleModal from "../components/ScheduleModal";
 import { tagModalAtom } from "../atoms/TagAtoms";
+import { tagListAtom } from "../atoms/HomeAtoms";
 
 const Tag = () => {
   // 일정 데이터 불러오기(api)
@@ -20,6 +21,7 @@ const Tag = () => {
   const [allTags, setAllTags] = useAtom(tagIdListAtom);
 
   const [, setTagModalOpen] = useAtom(tagModalAtom);
+  const [, setTagList] = useAtom(tagListAtom);
 
   //페이지가 처음 로드 될 때 태그 목록을 가져온다.
   useEffect(() => {
@@ -27,6 +29,13 @@ const Tag = () => {
       try {
         const tags = await getTagList(); // 실제 API 호출
         setAllTags(tags); // 응답 결과 저장
+        const newTags = tags
+          .map((tag) => tag.name)
+          .map((name) => ({
+            value: name,
+            label: name,
+          }));
+        setTagList(newTags);
       } catch (error) {
         console.error("태그 불러오기 실패:", error);
       }


### PR DESCRIPTION
- getTagApi 제거 후 getTagListApi로 통일
- - 이 과정에서 데이터 가공을 거치지 않는다.

- 가공이 필요한 경우 해당 컴포넌트에서 가공 후 사용 -> scheduleModal에서 가공 처리 필요

- atom 통일 : 현재는 tagIdListAtom, tagListAtom 중 하나만 사용

- select 시 색상 반영 및 수정일 경우 기존에 선택된 tag가 보이게 수정 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 태그 목록이 올바르게 표시되도록 태그 데이터 구조를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->