### PR TITLE
feat: 단계별 저장 후 편집 제한 및 이동 버튼 UI 개선

### DIFF
--- a/src/components/examplan/ExamPlanStep1.jsx
+++ b/src/components/examplan/ExamPlanStep1.jsx
@@ -31,8 +31,12 @@ const ExamPlanStep1 = ({
   ]);
 
   const [showCalendar, setShowCalendar] = useState(false);
+  const isReadonly =
+    formData.subjects && formData.subjects.length > 0;
 
   const handleChange = (e) => {
+    if (isReadonly) return;
+
     const { name, value } = e.target;
     setLocalData((prev) => ({
       ...prev,
@@ -41,6 +45,8 @@ const ExamPlanStep1 = ({
   };
 
   const handleDateChange = (item) => {
+    if (isReadonly) return;
+
     const newStart = item.selection.startDate;
     const newEnd = item.selection.endDate;
 
@@ -52,7 +58,17 @@ const ExamPlanStep1 = ({
     }));
   };
 
+  const handleCalendarToggle = () => {
+    if (isReadonly) return; // readonly 상태에서는 캘린더 열 수 없음
+    setShowCalendar(!showCalendar);
+  };
+
   const handleNext = () => {
+    if (isReadonly) {
+      nextStep();
+      return;
+    }
+
     if (
       !localData.examName ||
       !localData.startDate ||
@@ -106,7 +122,12 @@ const ExamPlanStep1 = ({
               name="examName"
               value={localData.examName}
               onChange={handleChange}
-              className="w-full p-4 text-lg border border-[#8E92BC] rounded-lg max-w-[400px] focus:outline-none h-14 box-border"
+              readOnly={isReadonly}
+              className={`w-full p-4 text-lg border border-[#8E92BC] rounded-lg max-w-[400px] focus:outline-none h-14 box-border ${
+                isReadonly
+                  ? "bg-gray-100 cursor-not-allowed text-gray-600"
+                  : "bg-white"
+              }`}
             />
           </div>
 
@@ -117,8 +138,12 @@ const ExamPlanStep1 = ({
             </label>
             <div className="flex flex-col gap-2 w-full max-w-[400px] relative">
               <div
-                onClick={() => setShowCalendar(!showCalendar)}
-                className="w-full p-4 text-lg border border-[#8E92BC] rounded-lg cursor-pointer bg-white flex items-center justify-between h-14 box-border"
+                onClick={handleCalendarToggle}
+                className={`w-full p-4 text-lg border border-[#8E92BC] rounded-lg flex items-center justify-between h-14 box-border ${
+                  isReadonly
+                    ? "bg-gray-100 cursor-not-allowed text-gray-600"
+                    : "bg-white cursor-pointer"
+                }`}
               >
                 <div className="text-lg font-normal font-['Inter'] leading-tight">
                   {localData.startDate && localData.endDate
@@ -135,10 +160,12 @@ const ExamPlanStep1 = ({
                 <img
                   src={CalendarIcon}
                   alt="calendar"
-                  className="w-6 h-6"
+                  className={`w-6 h-6 ${
+                    isReadonly ? "opacity-50" : ""
+                  }`}
                 />
               </div>
-              {showCalendar && (
+              {showCalendar && !isReadonly && (
                 <div className="absolute z-10 top-full mt-8 left-1/2 transform -translate-x-1/2">
                   <DateRange
                     editableDateInputs={true}

--- a/src/components/examplan/ExamPlanStep2.jsx
+++ b/src/components/examplan/ExamPlanStep2.jsx
@@ -22,6 +22,12 @@ const ExamPlanStep2 = ({
     useState(false);
   const [isAddingCustom, setIsAddingCustom] = useState(false); // 직접 추가
   const [customInput, setCustomInput] = useState("");
+  const [isSubjectsLocked, setIsSubjectsLocked] = useState(
+    formData.subjects && formData.subjects.length > 0
+  );
+  const [isDetailLocked, setIsDetailLocked] = useState(
+    formData.averageSubjectsPerDay > 0
+  );
 
   // 로컬스토리지에서 시간표 가져오기
   useEffect(() => {
@@ -107,6 +113,7 @@ const ExamPlanStep2 = ({
       return;
     }
     setShowDetailSetting(true);
+    setIsSubjectsLocked(true);
   };
 
   // 오른쪽 저장 버튼
@@ -115,6 +122,7 @@ const ExamPlanStep2 = ({
       subjects: selectedSubjects,
       averageSubjectsPerDay,
     });
+    setIsDetailLocked(true);
     alert("상세 설정이 저장되었습니다.");
   };
 
@@ -209,12 +217,18 @@ const ExamPlanStep2 = ({
                 {subjects.map((subject) => (
                   <button
                     key={subject}
+                    onClick={() =>
+                      !isSubjectsLocked && toggleSubject(subject)
+                    }
                     className={`w-[200px] lg:w-[250px] min-h-[60px] border px-4 py-3 rounded-lg text-left font-semibold mb-2 ${
                       selectedSubjects.includes(subject)
                         ? "bg-[#D0D7E2] border-[#27374D]"
                         : "bg-white"
+                    } ${
+                      isSubjectsLocked
+                        ? "pointer-events-none opacity-50"
+                        : ""
                     }`}
-                    onClick={() => toggleSubject(subject)}
                   >
                     {subject}
                   </button>
@@ -222,17 +236,21 @@ const ExamPlanStep2 = ({
               </div>
 
               {/* 직접 추가 버튼 */}
-              {!isAddingCustom ? (
+              {!isAddingCustom && !isSubjectsLocked ? (
                 <button
                   className="w-[200px] lg:w-[250px] min-h-[60px] border px-4 py-3 rounded-lg font-semibold text-left mb-2"
                   onClick={() => setIsAddingCustom(true)}
                 >
                   + 직접 추가
                 </button>
-              ) : (
+              ) : null}
+
+              {/* 직접 추가 입력창 */}
+              {isAddingCustom && (
                 <div className="relative w-[200px] lg:w-[250px]">
                   <input
                     type="text"
+                    disabled={isSubjectsLocked}
                     value={customInput}
                     onChange={(e) =>
                       setCustomInput(e.target.value)
@@ -256,8 +274,13 @@ const ExamPlanStep2 = ({
                     autoFocus
                   />
                   <button
+                    disabled={isSubjectsLocked}
                     onClick={handleAddCustomSubject}
-                    className="absolute right-2 top-1/2 transform -translate-y-1/2 w-8 h-8 bg-[#27374D] text-white rounded flex items-center justify-center text-lg font-bold hover:bg-[#1e2832]"
+                    className={`absolute right-2 top-1/2 transform -translate-y-1/2 w-8 h-8 rounded flex items-center justify-center text-lg font-bold ${
+                      isSubjectsLocked
+                        ? "bg-gray-300 text-gray-500 cursor-not-allowed"
+                        : "bg-[#27374D] text-white hover:bg-[#1e2832]"
+                    }`}
                   >
                     +
                   </button>
@@ -265,12 +288,14 @@ const ExamPlanStep2 = ({
               )}
 
               {/* 저장 버튼 */}
-              <button
-                onClick={handleSaveSubjects}
-                className="w-[80px] h-[32px] bg-[#27374D] text-white rounded-3xl absolute bottom-0 left-1/2 transform -translate-x-1/2"
-              >
-                저장
-              </button>
+              {!isSubjectsLocked && (
+                <button
+                  onClick={handleSaveSubjects}
+                  className="w-[80px] h-[32px] bg-[#27374D] text-white rounded-3xl absolute bottom-0 left-1/2 transform -translate-x-1/2"
+                >
+                  저장
+                </button>
+              )}
             </div>
           </div>
 
@@ -292,11 +317,17 @@ const ExamPlanStep2 = ({
                 <div className="flex items-center mt-32 gap-6">
                   <button
                     onClick={() =>
+                      !isDetailLocked &&
                       setAverageSubjectsPerDay((prev) =>
                         Math.max(1, prev - 1)
                       )
                     }
-                    className="border p-2 rounded"
+                    disabled={isDetailLocked}
+                    className={`border p-2 rounded ${
+                      isDetailLocked
+                        ? "opacity-50 cursor-not-allowed"
+                        : ""
+                    }`}
                   >
                     <Minus size={24} />
                   </button>
@@ -305,21 +336,31 @@ const ExamPlanStep2 = ({
                   </span>
                   <button
                     onClick={() =>
+                      !isDetailLocked &&
                       setAverageSubjectsPerDay(
                         (prev) => prev + 1
                       )
                     }
-                    className="border p-2 rounded"
+                    disabled={isDetailLocked}
+                    className={`border p-2 rounded ${
+                      isDetailLocked
+                        ? "opacity-50 cursor-not-allowed"
+                        : ""
+                    }`}
                   >
                     <Plus size={24} />
                   </button>
                 </div>
-                <button
-                  onClick={handleSaveDetailSetting}
-                  className="w-[80px] h-[32px] bg-[#27374D] text-white rounded-3xl absolute bottom-0 left-1/2 transform -translate-x-1/2"
-                >
-                  저장
-                </button>
+
+                {/* 저장 버튼 */}
+                {!isDetailLocked && (
+                  <button
+                    onClick={handleSaveDetailSetting}
+                    className="w-[80px] h-[32px] bg-[#27374D] text-white rounded-3xl absolute bottom-0 left-1/2 transform -translate-x-1/2"
+                  >
+                    저장
+                  </button>
+                )}
               </div>
             )}
           </div>

--- a/src/components/examplan/ExamPlanStep3.jsx
+++ b/src/components/examplan/ExamPlanStep3.jsx
@@ -24,7 +24,11 @@ const ExamPlanStep3 = ({
       });
       setRatios(initialRatios);
     }
-  }, [formData.subjects, formData.subjectRatios]);
+
+    if (formData.isSubjectRatiosSaved) {
+      setIsSaved(true);
+    }
+  }, [formData.subjects, formData.subjectRatios, formData.isSubjectRatiosSaved]);
 
   const handleRatioChange = (subject, value) => {
     setRatios((prev) => ({
@@ -59,6 +63,10 @@ const ExamPlanStep3 = ({
   const handleSaveRatioSetting = () => {
     if (validateAndSaveRatios()) {
       alert("비율 설정이 저장되었습니다.");
+      updateFormData({
+        subjectRatios: ratios,
+        isSubjectRatiosSaved: true, 
+      });
       setIsSaved(true);
     }
   };
@@ -113,6 +121,7 @@ const ExamPlanStep3 = ({
                     min="0"
                     max="100"
                     step="1"
+                    disabled={isSaved}
                     value={ratios[subject] || 0}
                     onChange={(e) =>
                       handleRatioChange(subject, e.target.value)
@@ -156,14 +165,16 @@ const ExamPlanStep3 = ({
           </div>
 
           {/* 저장 버튼 */}
-          <div className="flex justify-center">
-            <button
-              onClick={handleSaveRatioSetting}
-              className="w-[80px] h-[32px] bg-[#27374D] text-white rounded-3xl"
-            >
-              저장
-            </button>
-          </div>
+          {!isSaved && (
+            <div className="flex justify-center">
+              <button
+                onClick={handleSaveRatioSetting}
+                className="w-[80px] h-[32px] bg-[#27374D] text-white rounded-3xl"
+              >
+                저장
+              </button>
+            </div>
+          )}
         </div>
 
         {/* 이동 버튼 */}

--- a/src/components/examplan/ExamPlanStep4.jsx
+++ b/src/components/examplan/ExamPlanStep4.jsx
@@ -217,14 +217,14 @@ const ExamPlanStep4 = ({
       <button
         type="button"
         onClick={prevStep}
-        className="fixed top-1/2 -translate-y-1/2 left-2 lg:left-[calc(11.75rem+1.5rem)] z-50 text-[#27374D]"
+        className="fixed top-1/2 -translate-y-1/2 left-4 lg:left-[calc(11.75rem+1.5rem)] z-50 text-[#27374D]"
       >
         <ChevronLeft size={49} />
       </button>
 
-      <div className="flex items-end max-w-7xl w-full px-4 gap-12 ml-16 lg:ml-0">
+      <div className="flex items-end max-w-7xl w-full px-4 gap-12">
         {/* 캘린더 */}
-        <div className="flex-1">
+        <div className="flex-1 pl-16 lg:pl-0">
           <FullCalendar
             plugins={[dayGridPlugin, interactionPlugin]}
             initialView="dayGridMonth"


### PR DESCRIPTION
# 작업 내용
`ExamPlanStep1`, `ExamPlanStep2`, `ExamPlanStep3` 1, 2, 3 단계에서 저장 시 이후 편집 불가하도록 기능 추가
`ExamPlanStep4` 화면 크기 축소 시 이동 버튼과 캘린더 겹치지 않도록 위치 조정

# 작업 브랜치
jiyeon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 과목이 이미 선택된 경우 1단계에서 입력 및 날짜 선택이 읽기 전용 모드로 전환됩니다.
  * 2단계에서 과목 선택 및 세부 설정을 저장하면 추가 수정이 불가능하도록 잠금 기능이 적용됩니다.
  * 3단계에서 비율 저장 시 슬라이더 및 저장 버튼이 비활성화되고, 변경 시 다시 수정이 가능합니다.

* **스타일**
  * 4단계에서 버튼 및 캘린더 영역의 위치와 여백이 조정되어 레이아웃이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->