### PR TITLE
feat: 모달 컴포넌트 포탈 추가

### DIFF
--- a/src/components/ScheduleModal.jsx
+++ b/src/components/ScheduleModal.jsx
@@ -3,7 +3,8 @@
 // setIsModalOpen : 모달을 열고 닫는 함수 useState로 관리
 // onChange : 모달에서 일정 수정 시 사용될 함수 - home에 있는 handleChange와 연결
 // onChange는 추후에 수정기능이 만들어지면 사용할 예정
-import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useEffect, useRef, useState } from "react";
 import { DateRange } from "react-date-range";
 import { format } from "date-fns";
 import "react-date-range/dist/styles.css";
@@ -37,6 +38,8 @@ import addTags from "../api/addTagsApi";
 import updateSchedules from "../api/updateScheduleApi";
 
 const ScheduleModal = () => {
+  //portals 사용
+  const modalRoot = document.getElementById("modal-root");
   //jotai
   const [, sethandleChange] = useAtom(handleChangeAtom);
   const [isModalOpen, setIsModalOpen] = useAtom(isModalOpenAtom);
@@ -321,7 +324,7 @@ const ScheduleModal = () => {
     "min-w-[4.8125rem] text-[0.90238rem] pr-[1.80469rem] pl-[1.80469rem] pt-[0.15038rem] pb-[0.15038rem]";
 
   if (data.id === null) {
-    return (
+    return createPortal(
       <div
         className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50"
         onClick={handleClose}
@@ -465,10 +468,11 @@ const ScheduleModal = () => {
             </section>
           </section>
         </div>
-      </div>
+      </div>,
+      modalRoot
     );
   }
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50"
       onClick={handleClose}
@@ -690,7 +694,8 @@ const ScheduleModal = () => {
           )}
         </section>
       </div>
-    </div>
+    </div>,
+    modalRoot
   );
 };
 

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -28,7 +28,10 @@ const MainLayout = () => {
   const shouldHideSidebar = location.pathname === "/study-plan";
 
   return (
-    <div className="flex w-full h-screen relative">
+    <div
+      id="main-layout"
+      className="flex w-full h-screen relative"
+    >
       {!shouldHideSidebar && (
         <>
           {/* 사이드바: showSidebar 상태로 제어 작아지면 사라지고 햄버거 버튼을 눌러야지 나온다. */}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 리팩터링
  - 일정 모달을 포털 기반으로 렌더링하도록 전환하여 오버레이 표시가 더 안정적으로 유지되며, 스크롤/레이어(z-index) 관련 시각적 이슈가 개선되었습니다. 기존 기능과 사용 흐름은 동일합니다.
- 잡무(Chores)
  - 메인 레이아웃 루트 요소에 식별자(id)를 추가했습니다. 화면 표시나 동작 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->