### PR TITLE
fix: 시간표 수정/삭제 시 id 매핑 오류 수정

### DIFF
--- a/src/components/timetable/TimeTableForm.jsx
+++ b/src/components/timetable/TimeTableForm.jsx
@@ -178,7 +178,6 @@ const normalizeManualSchedule = (data) => {
       } else {
         // 현재 그룹을 merged에 푸시
         merged.push({
-          id: currentOriginals[0]?.id ?? null,
           originalData: [...currentOriginals],
           name: subject,
           day,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 수동으로 일정 그룹을 병합할 때 기존 항목의 식별자가 함께 따라가 덮어쓰기·중복 저장이 발생하던 문제를 수정했습니다.
  * 이제 병합된 일정은 항상 새 항목으로 정상 생성되어 저장/동기화 오류가 줄어들고, 목록 및 상세 화면에서도 일관되게 표시됩니다.
  * 예기치 않은 편집 영향(다른 일정 변경, 히스토리 꼬임 등)을 방지하여 병합 작업의 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->